### PR TITLE
Build from source on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,11 @@ jobs:
         run: |
           pacman -S --needed --noconfirm ${{ env.PKG_MSYS2_MINGW64 }}
 
+      - name: Install deps on macOS to build share + from source
+        if: runner.os == 'macOS' && matrix.alien-install-type == 'share'
+        run:
+          brew install boost xz
+
       - name: Install unzip on Windows
         if: runner.os == 'Windows' && matrix.dist == 'strawberry'
         run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,5 +153,7 @@ jobs:
           echo "ALIEN_INSTALL_TYPE=${{ matrix.alien-install-type }}" >> $GITHUB_ENV
 
       - name: Run tests
+        env:
+          ALIEN_BUILD_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cpanm --verbose --test-only .

--- a/alienfile
+++ b/alienfile
@@ -73,9 +73,12 @@ share {
   } else {
     plugin 'Build::CMake';
     build [
-      ['%{cmake}', @{ meta->prop->{plugin_build_cmake}->{args} }, '%{.install.extract}'],
-      '%{make}',
-      '%{make} install',
+      ['%{cmake}', @{ meta->prop->{plugin_build_cmake}->{args} },
+	'-S' => '%{.install.extract}',
+	'-B' => '_build',
+      ],
+      [ '%{make}', qw(-C _build), ],
+      [ '%{make}', qw(-C _build), 'install' ],
     ];
   }
 }


### PR DESCRIPTION
- Add deps to build from source on macOS
- Add `ALIEN_BUILD_GITHUB_TOKEN`
- CMake out-of-source build
